### PR TITLE
csegtrack bugfix

### DIFF
--- a/utgb-core/src/main/java/org/utgenome/gwt/utgb/client/track/lib/CSEGTrack.java
+++ b/utgb-core/src/main/java/org/utgenome/gwt/utgb/client/track/lib/CSEGTrack.java
@@ -122,7 +122,7 @@ public class CSEGTrack extends GenomeTrack {
 	public void draw() {
 		loadConfig();
 		TrackConfig config = getConfig();
-		String path = config.getString(CONFIG_PATH, "file not found");
+		String path = config.getString(CONFIG_PATH, "");
 		StringBuilder sb = new StringBuilder(256);
 		sb.append("utgb-core/CSEGViewer?%%q&ih=");
 		sb.append(param_total_height);

--- a/utgb-core/src/main/java/org/utgenome/gwt/utgb/server/app/CSEGViewer.java
+++ b/utgb-core/src/main/java/org/utgenome/gwt/utgb/server/app/CSEGViewer.java
@@ -276,7 +276,12 @@ public class CSEGViewer extends WebTrackBase {
 		try {
 			// this will load database file specified in config/development.silk file 
 			String dbFolder = getTrackConfigProperty("utgb.db.folder", getProjectRootPath() + "/db");
-			File dbFile = new File(dbFolder, String.format("p.patens/combined.genmap.imputed.seg.sqlite"));
+			File dbFile = null;
+			if (fileName == "") {
+				dbFile = new File(dbFolder, String.format("p.patens/combined.genmap.imputed.seg.sqlite"));
+			}
+			else
+				dbFile = new File(getProjectRootPath(), fileName);
 			if (!dbFile.exists())
 				throw new UTGBException(UTGBErrorCode.MISSING_FILES, "DB file doesn't exist: " + dbFile);
 			SQLiteAccess db = null;


### PR DESCRIPTION
corrected a problem that csegtrack reads the default file ignoring the files specified in the silk file.
